### PR TITLE
fix: windows support for extensions

### DIFF
--- a/lib/node-runner.rb
+++ b/lib/node-runner.rb
@@ -117,16 +117,20 @@ class NodeRunner::Executor
 
   def locate_executable(command)
     commands = Array(command)
+    exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+    exts << ''
 
     commands.find { |cmd|
       if File.executable? cmd
         cmd
       else
-        path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |p|
-          full_path = File.join(p, cmd)
-          File.executable?(full_path) && File.file?(full_path)
+        path = ENV['PATH'].split(File::PATH_SEPARATOR).flat_map { |p|
+          exts.map { |e| File.join(p, "#{cmd}#{e}") }
+        }.find { |p|
+          File.executable?(p) && File.file?(p)
         }
-        path && File.expand_path(cmd, path)
+
+        path && File.expand_path(path)
       end
     }
   end


### PR DESCRIPTION
Hello Bridgetown 👋

First of all, thanks for the lightweight package — we're using it in [Bookshop](https://github.com/CloudCannon/bookshop) to implement core logic in JavaScript without having to duplicate logic into Ruby.

We're hitting an issue on Windows, where NodeRunner currently fails its test suite on my machine.  

Currently, the `locate_executable` function enumerates all PATHs end checks for the existence of the command (`node`) in each folder. This works well on UNIX systems, but does not handle the extensions on Windows. 

The default node install on Windows is `C:\Program Files\nodejs\node.exe` — the issue being `locate_executable` tries `C:\Program Files\nodejs\node` (which doesn't exist), but then doesn't enumerate each possible executable path.

This patch loops through all extensions in `ENV['PATHEXT']` to try find the command file. It resolves the test suite on my Windows machine, and the tests still pass on my Mac.

Tied to: https://github.com/CloudCannon/eleventy-bookshop-starter/issues/1
Tied to: https://github.com/CloudCannon/bookshop/pull/51